### PR TITLE
Fix broken getPrFileNames() function

### DIFF
--- a/pkg/labeler.go
+++ b/pkg/labeler.go
@@ -279,13 +279,14 @@ func (l *Labeler) findMatches(pr *gh.PullRequest, config *LabelerConfigV1) (Labe
 // getPrFileNames returns all of the file names (old and new) of files changed in the given PR
 func getPrFileNames(pr *gh.PullRequest) ([]string, error) {
 	ghToken := os.Getenv("GITHUB_TOKEN")
-	diffReq, err := http.NewRequest("GET", pr.GetDiffURL(), nil)
+	diffReq, err := http.NewRequest("GET", pr.GetURL(), nil)
 
 	if err != nil {
 		return nil, err
 	}
 
 	diffReq.Header.Add("Authorization", "Bearer "+ghToken)
+	diffReq.Header.Add("Accept", "application/vnd.github.v3.diff")
 	diffRes, err := http.DefaultClient.Do(diffReq)
 
 	if err != nil {


### PR DESCRIPTION
### Background

- The current `getPrFileNames()` function doesn't work.
- `https://github.com/:owner/:repo/pull/:number.diff` doesn't accept `Authorization` token.
- Closes #19 


### Problem Solving

- https://stackoverflow.com/questions/35471316/using-curl-how-do-i-download-a-diff-file-from-a-private-repository-on-github
- Use `https://api.github.com/repos/:owner/:repo/pulls/:number` API
- Tested with my project. This works well.


### Known Issues

- `github.com/waigani/diffparser` package cannot parse correctly with `renamed` diff.