### PR TITLE
Remove trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-		
+
     steps:
     - uses: srvaroa/labeler@master
       env:


### PR DESCRIPTION
### Background

- There are some whitespace characters in `README.md`
  - Caused by #18 