### PR TITLE
Add base branch matching

### DIFF
--- a/pkg/labeler_test.go
+++ b/pkg/labeler_test.go
@@ -241,6 +241,36 @@ func TestHandleEvent(t *testing.T) {
 			expectedLabels: []string{},
 		},
 		TestCase{
+			payloads: []string{"create_pr"},
+			name:     "Test the base branch rule (matching)",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					LabelMatcher{
+						Label:      "Branch",
+						BaseBranch: "^master",
+					},
+				},
+			},
+			initialLabels:  []string{},
+			expectedLabels: []string{"Branch"},
+		},
+		TestCase{
+			payloads: []string{"create_pr"},
+			name:     "Test the base branch rule (not matching)",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					LabelMatcher{
+						Label:      "Branch",
+						BaseBranch: "^does/not-match/*",
+					},
+				},
+			},
+			initialLabels:  []string{},
+			expectedLabels: []string{},
+		},
+		TestCase{
 			payloads: []string{"diff_pr"},
 			name:     "Test the files rule",
 			config: LabelerConfigV1{


### PR DESCRIPTION
Allow the specifying of the base branch along with the matching of a
head branch. This is a quite a simple change as we use the same code for
branch matching, but tailor it for base branches.

This is great for my usage, as I can then label new PRs dependant on
where they're going to land, helping priortize and categorize incoming
changes to a repo.