### PR TITLE
Use pre-built binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 coverage.out
 action
+action.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine
+FROM alpine:3.17.2
 
 LABEL "com.github.actions.name"="Condition-based Pull Request labeller" \
           "com.github.actions.description"="Automatically label pull requests based on rules" \
@@ -7,11 +7,8 @@ LABEL "com.github.actions.name"="Condition-based Pull Request labeller" \
           "maintainer"="Galo Navarro <anglorvaroa@gmail.com>" \
           "repository"="https://github.com/srvaroa/labeler"
 
-RUN apk add --no-cache git
-
-WORKDIR /go/src/app
-COPY . .
-ENV GO111MODULE=on
-ENV GOPROXY=https://proxy.golang.org
-RUN go build -o action ./cmd
-ENTRYPOINT ["/go/src/app/action"]
+WORKDIR /
+ARG ASSET_URL=https://github.com/srvaroa/labeler/releases/latest/download/action.tar.gz
+RUN apk --no-cache add curl
+RUN curl -sSL $ASSET_URL | tar xzvf -
+ENTRYPOINT ["/action"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to date.
 ### How to trigger action
 
 To trigger the action on events, add a file `.github/workflows/main.yml`
-to your repository with these contents:
+to your repository: 
 
 ```yaml
 name: Label PRs
@@ -49,6 +49,10 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
+
+Using `@master` will run the latest available release. Feel free to pin
+this to a specific version from the [releases
+page](https://github.com/srvaroa/labeler/releases).
 
 Use the [`on`
 clause](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)


### PR DESCRIPTION
* Brings the build down to ~10 seconds from ~26.
* Decouples build from execution, so we facilitate go version upgrades (a recent upgrade do go-github@v50 required go 1.17 but this broke the label executor as ubuntu-latest doesn't support go 1.17 out of the box).

Signed-off-by: Galo Navarro <anglorvaroa@gmail.com>
