### PR TITLE
Allow negating conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,35 @@ labels:
 The `WIP` label will be set if the title matches `^WIP:.*` OR the label
 is not in a mergeable state.
 
+Adding a `negate` property inside the label block will negate the
+result of the evaluation of all conditions inside the label. For
+example:
+
+```yaml
+version: 1
+labels:
+- label: "unknown"
+  negate: true
+  branch: "(master|hotfix)"
+```
+
+In this case, label `unknown` will be set if the branch does NOT match
+`master` or `hotfix`.
+
+The same behaviour occurs with multiple conditions:
+
+```yaml
+version: 1
+labels:
+- label: "unknown"
+  negate: true
+  branch: "master"
+  title: "(feat).*"
+```
+
+Only PRs that do NOT match one of the two conditions will get the
+`unknown` label.
+
 ## Append-only mode
 
 The default behaviour of this action includes *removing* labels that

--- a/pkg/labeler.go
+++ b/pkg/labeler.go
@@ -10,6 +10,7 @@ import (
 
 type LabelMatcher struct {
 	Label      string
+	Negate     bool
 	Title      string
 	Branch     string
 	BaseBranch string `yaml:"base-branch"`
@@ -232,6 +233,12 @@ func (l *Labeler) findMatches(target *Target, config *LabelerConfigV1) (LabelUpd
 			if isMatched {
 				continue
 			}
+		}
+
+		if matcher.Negate {
+			result, _ := labelUpdates.set[label]
+			labelUpdates.set[label] = !result
+			log.Printf("[%s] is negated from %t", label, result)
 		}
 	}
 

--- a/pkg/labeler_test.go
+++ b/pkg/labeler_test.go
@@ -308,6 +308,23 @@ func TestHandleEvent(t *testing.T) {
 		},
 		{
 			event:    "pull_request",
+			payloads: []string{"small_pr"},
+			name:     "Test the branch rule (matching, but negated)",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					{
+						Label:  "Branch",
+						Negate: true,
+						Branch: "^does/not-match/*",
+					},
+				},
+			},
+			initialLabels:  []string{},
+			expectedLabels: []string{"Branch"},
+		},
+		{
+			event:    "pull_request",
 			payloads: []string{"create_pr"},
 			name:     "Test the base branch rule (matching)",
 			config: LabelerConfigV1{
@@ -387,6 +404,41 @@ func TestHandleEvent(t *testing.T) {
 			},
 			initialLabels:  []string{},
 			expectedLabels: []string{"Files"},
+		},
+		{
+			event:    "pull_request",
+			payloads: []string{"small_pr"},
+			name:     "Multiple conditions for the same label function as AND",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					{
+						Label:  "Branch",
+						Branch: "^srvaroa-patch.*",
+						Title:  "^W.*Update.*",
+					},
+				},
+			},
+			initialLabels:  []string{},
+			expectedLabels: []string{"Branch"},
+		},
+		{
+			event:    "pull_request",
+			payloads: []string{"small_pr"},
+			name:     "Multiple conditions for the same label function as AND, but negated make a true",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					{
+						Label:  "Branch",
+						Negate: true,
+						Title:  "^Update.*",
+						Branch: "^srvaroa-patch.*",
+					},
+				},
+			},
+			initialLabels:  []string{"Branch"},
+			expectedLabels: []string{"Branch"},
 		},
 		{
 			event:    "pull_request",


### PR DESCRIPTION
Mainly a workaround for Go's lack of support to negative-lookahead regex.

This feature allows negating the result of the conditions applied to each label.

Signed-off-by: Galo Navarro <anglorvaroa@gmail.com>
