### PR TITLE
ci: Bump wangyoucao577/go-release-action to v1.40

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: wangyoucao577/go-release-action@v1.35
+    - uses: wangyoucao577/go-release-action@v1.40
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux


### PR DESCRIPTION
Closes #92
Closes #93 

The release workflow is failing (https://github.com/srvaroa/labeler/actions/runs/6465977654) due to the format change of `https://go.dev/VERSION?m=text` API. It is fixed in go-release-action@v1.39 (https://github.com/wangyoucao577/go-release-action/pull/130). This pull request bumps the action version to the latest to include this fix.

Creating another release (maybe 1.6.3) after merging this will solve #92 and #93.