### PR TITLE
Allow error code on action failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_CONFIG_PATH: ./.github/labeler.yml
+          INPUT_FAIL_ON_ERROR: true
         run: ./action
 
       - name: Check that the docker image builds

--- a/README.md
+++ b/README.md
@@ -137,9 +137,20 @@ will read the config file from the local checkout.
 
 ## Troubleshooting
 
-This action will avoid failing in all cases, so if you're experiencing
-unexpected behaviour it's worth looking at execution logs. Typical
-errors are related to non-existing configuration file or invalid yaml.
+To avoid blocking CI pipelines, the action will never return an error
+code and just log information about the problem. Typical errors are
+related to non-existing configuration file or invalid yaml.
+
+If you wish to make the action fail the pipeline, you can override this
+behaviour thus:
+
+    steps:
+    - uses: srvaroa/labeler@master
+      with:
+        fail_on_error: true
+
+When `fail_on_error` is enabled, any failure inside the action will
+exit the action process with an error code.
 
 ## Configuring matching rules
 


### PR DESCRIPTION
Explained in the readme. This is mainly useful for our own CI, but can
also be used when running the action.

Signed-off-by: Galo Navarro <anglorvaroa@gmail.com>
