### PR TITLE
Fix "Author is member" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ This condition is satisfied when the author of the PR is an active
 member of the given team.
 
 ```yaml
-author-is-member: CoreTeam
+author-in-team: CoreTeam
 ```
 
 ### Authors (PRs and Issues)  <a name="authors" />


### PR DESCRIPTION
It seems the correct YAML key is actually `author-in-team` https://github.com/srvaroa/labeler/blob/2673f66494a450dbbe596ae034b761ea47d80104/pkg/labeler.go#L25