### PR TITLE
Check that MergeableState is clean for mergeable

### DIFF
--- a/pkg/condition_ismergeable.go
+++ b/pkg/condition_ismergeable.go
@@ -18,10 +18,14 @@ func IsMergeableCondition() Condition {
 			if err != nil {
 				return false, fmt.Errorf("mergeable is not set in config")
 			}
+
+			//  Check both the mergeable state and the mergeable flag
+			isMergeable := target.ghPR.GetMergeable() && target.ghPR.GetMergeableState() == "clean"
+
 			if b {
-				return target.ghPR.GetMergeable(), nil
+				return isMergeable, nil
 			}
-			return !target.ghPR.GetMergeable(), nil
+			return !isMergeable, nil
 		},
 	}
 }

--- a/pkg/labeler_test.go
+++ b/pkg/labeler_test.go
@@ -1049,6 +1049,22 @@ func TestHandleEvent(t *testing.T) {
 			initialLabels:  []string{"Meh"},
 			expectedLabels: []string{"Meh", "ShouldAppear"},
 		},
+		{
+			event:    "pull_request",
+			payloads: []string{"create_pr_mergeable_not_clean"},
+			name:     "Don't add label when PR is mergeable but state is not clean",
+			config: LabelerConfigV1{
+				Version: 1,
+				Labels: []LabelMatcher{
+					{
+						Label:     "CanMerge",
+						Mergeable: "True",
+					},
+				},
+			},
+			initialLabels:  []string{},
+			expectedLabels: []string{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1059,6 +1075,7 @@ func TestHandleEvent(t *testing.T) {
 					fmt.Printf("Test `%s`: failed to load %s\n", tc.name, file)
 					t.Fatal(err)
 				}
+				fmt.Printf("Loaded payload: %s\n", string(payload))
 
 				fmt.Printf("--> TEST: %s \n", tc.name)
 				l := NewTestLabeler(t, tc)

--- a/test_data/create_pr_mergeable_not_clean_payload
+++ b/test_data/create_pr_mergeable_not_clean_payload
@@ -1,0 +1,41 @@
+{
+  "action": "opened",
+  "number": 1,
+  "pull_request": {
+    "number": 1,
+    "state": "open",
+    "locked": false,
+    "title": "Update test",
+    "user": {
+      "login": "srvaroa",
+      "type": "User"
+    },
+    "body": "Test PR",
+    "base": {
+      "repo": {
+        "name": "labeler",
+        "owner": {
+          "login": "srvaroa"
+        }
+      }
+    },
+    "created_at": "2019-05-24T22:03:59Z",
+    "updated_at": "2019-05-24T22:03:59Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignee": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "milestone": null,
+    "commits": 1,
+    "additions": 1,
+    "deletions": 1,
+    "changed_files": 1,
+    "mergeable": true,
+    "mergeable_state": "blocked",
+    "author_association": "OWNER"
+  }
+}


### PR DESCRIPTION
Resolves #162

Extends the `mergeable` check to also ensure that the the [mergeable state](https://docs.github.com/en/graphql/reference/enums#mergestatestatus) is `'clean'`. This ensures that the pull request is truly mergeable. This resolves cases where all status checks have passed (`GetMergeable` returns true) but review is required on the PR before merging.