### PR TITLE
Only process open issues and PRs

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -236,12 +236,16 @@ func newLabeler(gh *github.Client, config *labeler.LabelerConfigV1) *labeler.Lab
 			},
 			ListIssuesByRepo: func(owner, repo string) ([]*github.Issue, error) {
 				issues, _, err := gh.Issues.ListByRepo(ctx,
-					owner, repo, &github.IssueListByRepoOptions{})
+					owner, repo, &github.IssueListByRepoOptions{
+						State: "open",
+					})
 				return issues, err
 			},
 			ListPRs: func(owner, repo string) ([]*github.PullRequest, error) {
 				prs, _, err := gh.PullRequests.List(ctx,
-					owner, repo, &github.PullRequestListOptions{})
+					owner, repo, &github.PullRequestListOptions{
+						State: "open",
+					})
 				return prs, err
 			},
 			IsUserMemberOfTeam: func(org, user, team string) (bool, error) {

--- a/pkg/labeler.go
+++ b/pkg/labeler.go
@@ -317,9 +317,14 @@ func (l *Labeler) ProcessAllIssues(owner, repo string) {
 		return
 	}
 
-	for _, pr := range issues {
-		err = l.ExecuteOn(wrapIssueAsTarget(pr))
-		log.Printf("Unable to execute action: %+v", err)
+	for _, issue := range issues {
+		if issue.State != nil && strings.ToLower(*issue.State) != "open" {
+			continue
+		}
+		err = l.ExecuteOn(wrapIssueAsTarget(issue))
+		if err != nil {
+			log.Printf("Unable to execute action on issue #%d: %+v", issue.GetNumber(), err)
+		}
 	}
 }
 
@@ -333,8 +338,13 @@ func (l *Labeler) ProcessAllPRs(owner, repo string) {
 	}
 
 	for _, pr := range prs {
+		if pr.State != nil && strings.ToLower(*pr.State) != "open" {
+			continue
+		}
 		err = l.ExecuteOn(wrapPrAsTarget(pr))
-		log.Printf("Unable to execute action: %+v", err)
+		if err != nil {
+			log.Printf("Unable to execute action on PR #%d: %+v", pr.GetNumber(), err)
+		}
 	}
 
 }

--- a/pkg/labeler_open_state_test.go
+++ b/pkg/labeler_open_state_test.go
@@ -1,0 +1,53 @@
+package labeler
+
+import (
+	"testing"
+
+	gh "github.com/google/go-github/v50/github"
+)
+
+func TestProcessAllIssuesAndPRsOnlyOpen(t *testing.T) {
+	calls := struct {
+		issues []int
+		prs    []int
+	}{[]int{}, []int{}}
+
+	fakeIssues := []*gh.Issue{
+		{Number: gh.Int(1), State: gh.String("open"), User: &gh.User{Login: gh.String("user1")}, RepositoryURL: gh.String("http://x/y/repo")},
+		{Number: gh.Int(2), State: gh.String("closed"), User: &gh.User{Login: gh.String("user2")}, RepositoryURL: gh.String("http://x/y/repo")},
+	}
+	fakePRs := []*gh.PullRequest{
+		{Number: gh.Int(10), State: gh.String("open"), User: &gh.User{Login: gh.String("user3")}, Base: &gh.PullRequestBranch{Repo: &gh.Repository{Name: gh.String("repo"), Owner: &gh.User{Login: gh.String("y")}}}},
+		{Number: gh.Int(11), State: gh.String("closed"), User: &gh.User{Login: gh.String("user4")}, Base: &gh.PullRequestBranch{Repo: &gh.Repository{Name: gh.String("repo"), Owner: &gh.User{Login: gh.String("y")}}}},
+	}
+
+	l := &Labeler{
+		FetchRepoConfig: func() (*LabelerConfigV1, error) {
+			return &LabelerConfigV1{Version: 1, Issues: true, Labels: []LabelMatcher{}}, nil
+		},
+		ReplaceLabels: func(target *Target, labels []string) error {
+			if target.ghIssue != nil {
+				calls.issues = append(calls.issues, target.IssueNo)
+			}
+			if target.ghPR != nil {
+				calls.prs = append(calls.prs, target.IssueNo)
+			}
+			return nil
+		},
+		GetCurrentLabels: func(target *Target) ([]string, error) { return nil, nil },
+		GitHubFacade: &GitHubFacade{
+			ListIssuesByRepo: func(owner, repo string) ([]*gh.Issue, error) { return fakeIssues, nil },
+			ListPRs:          func(owner, repo string) ([]*gh.PullRequest, error) { return fakePRs, nil },
+		},
+	}
+
+	l.ProcessAllIssues("y", "repo")
+	l.ProcessAllPRs("y", "repo")
+
+	if len(calls.issues) != 1 || calls.issues[0] != 1 {
+		t.Errorf("Expected only open issue #1 to be processed, got %+v", calls.issues)
+	}
+	if len(calls.prs) != 1 || calls.prs[0] != 10 {
+		t.Errorf("Expected only open PR #10 to be processed, got %+v", calls.prs)
+	}
+}

--- a/pkg/labeler_test.go
+++ b/pkg/labeler_test.go
@@ -125,6 +125,14 @@ func TestHandleEvent(t *testing.T) {
 			expectedLabels: []string{"ShouldStay"},
 		},
 		{
+			event:          "issues",
+			payloads:       []string{"issue_open"},
+			name:           "Do not process issues if Issues flag is not set",
+			config:         LabelerConfigV1{Version: 1, Labels: []LabelMatcher{{Label: "Test", Title: "^Testy.*t"}}},
+			initialLabels:  []string{"ShouldStay"},
+			expectedLabels: []string{"ShouldStay"},
+		},
+		{
 			event:    "issues",
 			payloads: []string{"issue_open"},
 			name:     "Do not process issues if Issues config is set to False",


### PR DESCRIPTION
Fixes a bug where closed issues and pull requests were being processed and relabeled. Now, only open issues and PRs are considered in scheduled runs. With unit test.

Fixes (#174)